### PR TITLE
Changes to accomodate free >=4.6 and the merging of comonad-transformers into comonad

### DIFF
--- a/Control/Alternative/Operational.hs
+++ b/Control/Alternative/Operational.hs
@@ -199,10 +199,11 @@ viewAlt :: ProgramAlt instr a -> ProgramViewAlt instr a
 viewAlt = viewAlt' . toAlt
 
 viewAlt' :: Alt (Coyoneda instr) a -> ProgramViewAlt instr a
-viewAlt' (Free.Pure a) = Pure a
-viewAlt' (Free.Ap (Coyoneda f i) next) = i :<**> viewAlt' (fmap (.f) next)
-viewAlt' (Free.Alt xs) = Many $ map viewAlt' xs
+viewAlt' (Free.Alt xs) = Many $ map viewAltF' xs
 
+viewAltF' :: AltF (Coyoneda instr) a -> ProgramViewAlt instr a
+viewAltF' (Free.Pure a) = Pure a
+viewAltF' (Free.Ap (Coyoneda f i) next) = i :<**> viewAlt' (fmap (.f) next)
 
 compileAlt :: ProgramViewAlt instr a -> ProgramAlt instr a
 compileAlt (Pure a) = pure a

--- a/Control/Monad/Trans/Operational.hs
+++ b/Control/Monad/Trans/Operational.hs
@@ -14,7 +14,7 @@ module Control.Monad.Trans.Operational
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Trans
-import Control.Monad.Trans.Free
+import Control.Monad.Trans.Free hiding (retract, retractT)
 import Control.Operational.Class
 import Control.Operational.Instruction
 import Data.Functor.Coyoneda

--- a/free-operational.cabal
+++ b/free-operational.cabal
@@ -77,7 +77,7 @@ library
   build-depends:       base == 4.*,
                        transformers >=0.3,
                        mtl >=2,
-                       free >=3.3,
-                       comonad-transformers >=3.0,
-                       kan-extensions >=3.7 && <3.8
+                       free >=4.6,
+                       comonad >=4.0,
+                       kan-extensions >=3.7
   


### PR DESCRIPTION
There are a couple relevant changes from free-3.3 to 4.6:
- `Control.Alternative.Free` was restructured a bit.
- Removal of `Control.MonadPlus.Free`. So we switch over to use `FreeT f []`.
  Also, comonad-transformers is now deprecated and `Data.Functor.Coproduct` was moved into comonad.

Is it really worth depending on that package just to re-export this module, though? After all, transformers(-compat) >=0.4 has `Data.Functor.Sum`, and @ekmett is thinking about [removing `Data.Functor.Coproduct` from comonad](https://github.com/ekmett/comonad/issues/14) in favour of that.
